### PR TITLE
Update official url in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
     version=_get_version(),
     description="Virtualbricks Virtualization Tools",
     author="Virtualbricks team",
-    url="https://launchpad.net/virtualbrick",
+    url="https://github.com/virtualsquare/virtualbricks",
     license="GPLv2",
     platforms=["linux2", "linux"],
     packages=[


### PR DESCRIPTION
It appears this is now the official repo for virtualbricks based on the email-thread about migrating from launchpad to github here, so this just updates the url to match that: https://lists.launchpad.net/virtualbricks/msg00004.html