### PR TITLE
Qemu 3.1: syntax changed for network interfaces

### DIFF
--- a/virtualbricks/virtualmachines.py
+++ b/virtualbricks/virtualmachines.py
@@ -759,20 +759,20 @@ class VirtualMachine(bricks.Brick):
         else:
             for i, link in enumerate(itertools.chain(self.plugs, self.socks)):
                 res.append("-device")
-                res.append("{1.model},vlan={0},mac={1.mac},id=eth{0}".format(
+                res.append("{1.model},mac={1.mac},id=vx{0},netdev=vx{0}".format(
                     i, link))
                 if link.sock and link.sock.mode == "hostonly":
-                    res.extend(("-net", "user,vlan={0}".format(i)))
+                    res.extend(("-netdev", "user,id=vx{0}".format(i)))
                 elif link.mode == "vde":
-                    res.append("-net")
-                    res.append("vde,vlan={0},sock={1}".format(
+                    res.append("-netdev")
+                    res.append("vde,id=vx{0},sock={1}".format(
                         i, link.sock.path.rstrip('[]')))
                 elif link.mode == "sock":
-                    res.append("-net")
-                    res.append("vde,vlan={0},sock={1}".format(
+                    res.append("-netdev")
+                    res.append("vde,id=vx{0},sock={1}".format(
                         i, link.path))
                 else:
-                    res.extend(["-net", "user"])
+                    res.extend(["-netdev", "user"])
 
         if self.config["cdromen"] and self.config["cdrom"]:
                 res.extend(["-cdrom", self.config["cdrom"]])


### PR DESCRIPTION
Replace legacy "-net" option with "-netdev"

@marcogiusti can you have a look? I don't have an older qemu to test if it breaks backward compatibility.

This should perhaps be based on the guessed qemu version, but "it works for me", so.

