### PR TITLE
Fixed missing libraries in install and updated twisted interface

### DIFF
--- a/README
+++ b/README
@@ -28,4 +28,6 @@ to install the dependencies, most notably pygraphviz. Pygraphviz
 requires a compiler, pkg-config and the development libraries for
 graphviz (libgraphviz-dev in Debian).
 
+If you prefer to use pkexec instead of the default gksu (now deprecated)
+remeber to change the corresponding line in `~/.virtualbricks.conf`.
 .. vim: ft=rst tw=72

--- a/README
+++ b/README
@@ -28,6 +28,13 @@ to install the dependencies, most notably pygraphviz. Pygraphviz
 requires a compiler, pkg-config and the development libraries for
 graphviz (libgraphviz-dev in Debian).
 
-If you prefer to use pkexec instead of the default gksu (now deprecated)
-remeber to change the corresponding line in `~/.virtualbricks.conf`.
-.. vim: ft=rst tw=72
+Setup
+============
+Before using virtualbricks directly you'll probably need to change some
+default env paths in the configuration file, that is usually placed in 
+`~/.virtualbricks.conf`.
+Remember to set `qemupath` and `vdepath` to your corresponding binaries
+path, as well as activating `kvm` and `ksm` if you are using them.
+
+If you prefer using pkexec instead of the default gksu (now
+deprecated), change the corresponding line in `~/.virtualbricks.conf`.

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,8 @@ setup(
         'Pillow',
         'pygraphviz',
         "Twisted>=12.0.0",
-        "zope.interface>=3.5"
+        "zope.interface>=3.5",
+        "PyGObject"
     ],
     extras_require={
         'test': ['mock']

--- a/virtualbricks/_log.py
+++ b/virtualbricks/_log.py
@@ -74,7 +74,7 @@ import logging
 import time
 
 from zope.interface import Interface, implementer
-from twisted.python.constants import NamedConstant, Names
+from constantly import NamedConstant, Names
 from twisted.python.failure import Failure
 from twisted.python.reflect import safe_str
 import twisted.python.log

--- a/virtualbricks/tools.py
+++ b/virtualbricks/tools.py
@@ -29,7 +29,7 @@ import struct
 
 from twisted.internet import defer
 from twisted.internet import utils
-from twisted.python import constants
+import constantly as constants
 
 from virtualbricks import log
 from virtualbricks import settings


### PR DESCRIPTION
Closes #7,
Hello, this is the promised PR for issue #7, I've added `PyGObject` as a required library for installation in the setup.py, changed all `twisted` instances with the updated interface - now, according to the official docs, we need to use the `constantly` library - and I added a part to the README, because as of now `gksu` is deprecated and I explained how to setup using the now supported `pkexec`.